### PR TITLE
Add Windows build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Media player with fully customizable UI. Based on VLC and Qt. Uses QML for UI cu
 * [Android](https://play.google.com/apps/testing/org.webchimera.desktop)
 * [Raspberry Pi/Raspbian](https://github.com/RSATom/WebChimera-desktop/releases/tag/RPi.v.0.3)
 
+### Building
+
+#### Windows
+
+1. Clone this repository recursively, like so: `git clone --recursive http://github.com/RSATom/WebChimera-desktop`
+2. Download and install `Visual Studio 2015` and make sure the `Visual C++` option is checked when installing
+3. Download and install `Qt 5.7.0` (or later) from [here](https://www.qt.io/download-open-source/#section-2) - pick the Windows **32-bit** installer for **VS 2015**
+4. Open Qt Creator, then open the WebChimera project file in WebChimera-desktop directory, configure it and click Build
+
 ### Demos
 * [basic](http://rsatom.github.io/WebChimera-desktop)
 


### PR DESCRIPTION
We should have that :)

thought that was a better format than prerequisite, but you can re-work it if you want into prerequisite

Also, btw, I hit that "-lvlc" library not found issue on OS X, we have to dig up how we solved it in WebChimera.js
